### PR TITLE
fix: add the github_token parameter to labeler

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -67,6 +67,7 @@ jobs:
     - name: Add labels to PR
       uses: actions-ecosystem/action-add-labels@v1
       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: ${{ steps.set-labels.outputs.labels }}
 
     - name: Assign PR creator


### PR DESCRIPTION
## ✍ Description

The following error occurred in the labeler's workflow:
https://github.com/oqtopus-team/tranqu/actions/runs/12172007861/job/33949929213
```
Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```

To address this issue, I added the `github_token` parameter.
