### PR TITLE
feat: add program and device type registry

### DIFF
--- a/src/tranqu/device_type_manager.py
+++ b/src/tranqu/device_type_manager.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from .tranqu_error import TranquError
+
+
+class DeviceLibNotFoundError(TranquError):
+    """Error raised when device library cannot be detected."""
+
+
+class DeviceTypeManager:
+    """Class that manages mapping between device types and library identifiers."""
+
+    def __init__(self) -> None:
+        self._type_registry: dict[type, str] = {}
+
+    def register_type(self, device_lib: str, device_type: type) -> None:
+        """Register a device type and its library identifier.
+
+        Args:
+            device_lib (str): Library identifier (e.g., "qiskit", "oqtopus")
+            device_type (Type): Device type class to register
+
+        """
+        self._type_registry[device_type] = device_lib
+
+    def detect_lib(self, device: Any) -> str:  # noqa: ANN401
+        """Detect library based on device type.
+
+        Args:
+            device (Any): Device to inspect
+
+        Returns:
+            str: Detected library identifier
+
+        Raises:
+            DeviceLibNotFoundError: When device type is not registered
+
+        """
+        for device_type, lib in self._type_registry.items():
+            if isinstance(device, device_type):
+                return lib
+
+        msg = (
+            "Could not detect device library. Please specify device_lib or "
+            "use register_device_type() to register the device type."
+        )
+        raise DeviceLibNotFoundError(msg)

--- a/src/tranqu/device_type_manager.py
+++ b/src/tranqu/device_type_manager.py
@@ -30,7 +30,7 @@ class DeviceTypeManager:
             device (Any): Device to inspect
 
         Returns:
-            str | None: Detected library identifier or None
+            str | None: Library identifier for registered device type, None otherwise
 
         """
         for device_type, lib in self._type_registry.items():

--- a/src/tranqu/device_type_manager.py
+++ b/src/tranqu/device_type_manager.py
@@ -23,25 +23,18 @@ class DeviceTypeManager:
         """
         self._type_registry[device_type] = device_lib
 
-    def detect_lib(self, device: Any) -> str:  # noqa: ANN401
+    def detect_lib(self, device: Any) -> str | None:  # noqa: ANN401
         """Detect library based on device type.
 
         Args:
             device (Any): Device to inspect
 
         Returns:
-            str: Detected library identifier
-
-        Raises:
-            DeviceLibNotFoundError: When device type is not registered
+            str | None: Detected library identifier or None
 
         """
         for device_type, lib in self._type_registry.items():
             if isinstance(device, device_type):
                 return lib
 
-        msg = (
-            "Could not detect device library. Please specify device_lib or "
-            "use register_device_type() to register the device type."
-        )
-        raise DeviceLibNotFoundError(msg)
+        return None

--- a/src/tranqu/program_type_manager.py
+++ b/src/tranqu/program_type_manager.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+from .tranqu_error import TranquError
+
+
+class ProgramLibNotFoundError(TranquError):
+    """Error when program library cannot be detected."""
+
+
+class ProgramTypeManager:
+    """Class that manages the mapping between program types and library identifiers."""
+
+    def __init__(self) -> None:
+        self._type_registry: dict[type, str] = {}
+
+    def register_type(self, program_lib: str, program_type: type) -> None:
+        """Register a program type and its library identifier.
+
+        Args:
+            program_lib (str): Library identifier (e.g., "qiskit", "tket")
+            program_type (Type): Program type class to register
+
+        """
+        self._type_registry[program_type] = program_lib
+
+    def detect_lib(self, program: Any) -> str:  # noqa: ANN401
+        """Detect the library based on the program type.
+
+        Args:
+            program (Any): Program to inspect
+
+        Returns:
+            str: Detected library identifier
+
+        Raises:
+            ProgramLibNotFoundError: If the program type is not registered
+
+        """
+        for program_type, lib in self._type_registry.items():
+            if isinstance(program, program_type):
+                return lib
+
+        msg = (
+            "Could not detect program library. Please either "
+            "specify program_lib or register the program type "
+            "using register_program_type()."
+        )
+        raise ProgramLibNotFoundError(msg)

--- a/src/tranqu/program_type_manager.py
+++ b/src/tranqu/program_type_manager.py
@@ -1,11 +1,5 @@
 from typing import Any
 
-from .tranqu_error import TranquError
-
-
-class ProgramLibNotFoundError(TranquError):
-    """Error when program library cannot be detected."""
-
 
 class ProgramTypeManager:
     """Class that manages the mapping between program types and library identifiers."""
@@ -23,26 +17,18 @@ class ProgramTypeManager:
         """
         self._type_registry[program_type] = program_lib
 
-    def detect_lib(self, program: Any) -> str:  # noqa: ANN401
+    def detect_lib(self, program: Any) -> str | None:  # noqa: ANN401
         """Detect the library based on the program type.
 
         Args:
             program (Any): Program to inspect
 
         Returns:
-            str: Detected library identifier
-
-        Raises:
-            ProgramLibNotFoundError: If the program type is not registered
+            str | None: Library identifier for registered program type, None otherwise
 
         """
         for program_type, lib in self._type_registry.items():
             if isinstance(program, program_type):
                 return lib
 
-        msg = (
-            "Could not detect program library. Please either "
-            "specify program_lib or register the program type "
-            "using register_program_type()."
-        )
-        raise ProgramLibNotFoundError(msg)
+        return None

--- a/src/tranqu/tranqu.py
+++ b/src/tranqu/tranqu.py
@@ -158,15 +158,17 @@ class Tranqu:
             self._transpiler_manager,
             self._program_converter_manager,
             self._device_converter_manager,
+            self._program_type_manager,
+            self._device_type_manager,
         )
 
         return dispatcher.dispatch(
             program,
-            program_lib or self._detect_program_lib(program),
+            program_lib,
             transpiler_lib,
             transpiler_options,
             device,
-            device_lib or self._detect_device_lib(program),
+            device_lib,
         )
 
     def register_transpiler(
@@ -284,30 +286,6 @@ class Tranqu:
 
         """
         self._device_type_manager.register_type(device_lib, device_type)
-
-    def _detect_program_lib(self, program: Any) -> str:  # noqa: ANN401
-        """Detect the program library based on the program's type.
-
-        Args:
-            program (Any): The program whose type should be checked
-
-        Returns:
-            str: The detected library identifier
-
-        """
-        return self._program_type_manager.detect_lib(program)
-
-    def _detect_device_lib(self, device: Any) -> str | None:  # noqa: ANN401
-        """Detect the device library based on the device's type.
-
-        Args:
-            device (Any): The device whose type should be checked
-
-        Returns:
-            str | None: The detected library identifier or None if not detected
-
-        """
-        return self._device_type_manager.detect_lib(device)
 
     def _register_builtin_program_converters(self) -> None:
         self.register_program_converter(

--- a/src/tranqu/tranqu.py
+++ b/src/tranqu/tranqu.py
@@ -166,7 +166,7 @@ class Tranqu:
             transpiler_lib,
             transpiler_options,
             device,
-            device_lib,
+            device_lib or self._detect_device_lib(program),
         )
 
     def register_transpiler(
@@ -296,6 +296,18 @@ class Tranqu:
 
         """
         return self._program_type_manager.detect_lib(program)
+
+    def _detect_device_lib(self, device: Any) -> str | None:  # noqa: ANN401
+        """Detect the device library based on the device's type.
+
+        Args:
+            device (Any): The device whose type should be checked
+
+        Returns:
+            str | None: The detected library identifier or None if not detected
+
+        """
+        return self._device_type_manager.detect_lib(device)
 
     def _register_builtin_program_converters(self) -> None:
         self.register_program_converter(

--- a/src/tranqu/transpiler_dispatcher.py
+++ b/src/tranqu/transpiler_dispatcher.py
@@ -13,6 +13,10 @@ class TranspilerDispatcherError(TranquError):
     """Base class for errors related to the transpiler dispatcher."""
 
 
+class ProgramLibNotFoundError(TranquError):
+    """Error when program library cannot be detected."""
+
+
 class ProgramNotSpecifiedError(TranspilerDispatcherError):
     """Error raised when no program is specified."""
 
@@ -99,7 +103,7 @@ class TranspilerDispatcher:
 
         Raises:
             ProgramNotSpecifiedError: Raised when no program is specified.
-            ProgramLibNotSpecifiedError: Raised when no program library is specified.
+            ProgramLibNotFoundError: Raised when program library cannot be detected.
             TranspilerLibNotSpecifiedError: Raised when no transpiler library
                 is specified.
             DeviceNotSpecifiedError: Raised when a device library is specified
@@ -118,10 +122,11 @@ class TranspilerDispatcher:
         )
         if detected_program_lib is None:
             msg = (
-                "No program library specified or detected. "
-                "Please specify a program format."
+                "Could not detect program library. Please either "
+                "specify program_lib or register the program type "
+                "using register_program_type()."
             )
-            raise ProgramLibNotSpecifiedError(msg)
+            raise ProgramLibNotFoundError(msg)
 
         detected_device_lib = (
             self._detect_device_lib(device) if device_lib is None else device_lib

--- a/src/tranqu/transpiler_dispatcher.py
+++ b/src/tranqu/transpiler_dispatcher.py
@@ -1,7 +1,9 @@
 from typing import Any
 
 from .device_converter import DeviceConverterManager
+from .device_type_manager import DeviceTypeManager
 from .program_converter import ProgramConverterManager
+from .program_type_manager import ProgramTypeManager
 from .tranqu_error import TranquError
 from .transpile_result import TranspileResult
 from .transpiler import TranspilerManager
@@ -51,6 +53,10 @@ class TranspilerDispatcher:
             quantum programs between different libraries.
         device_converter_manager (DeviceConverterManager): Handles conversion of
             device specifications between different libraries.
+        program_type_manager (ProgramTypeManager): Manages detection of program types
+            and their corresponding libraries.
+        device_type_manager (DeviceTypeManager): Manages detection of device types
+            and their corresponding libraries.
 
     """
 
@@ -59,17 +65,21 @@ class TranspilerDispatcher:
         transpiler_manager: TranspilerManager,
         program_converter_manager: ProgramConverterManager,
         device_converter_manager: DeviceConverterManager,
+        program_type_manager: ProgramTypeManager,
+        device_type_manager: DeviceTypeManager,
     ) -> None:
         self._transpiler_manager = transpiler_manager
         self._program_converter_manager = program_converter_manager
         self._device_converter_manager = device_converter_manager
+        self._program_type_manager = program_type_manager
+        self._device_type_manager = device_type_manager
 
     def dispatch(  # noqa: PLR0913 PLR0917
         self,
         program: Any,  # noqa: ANN401
-        program_lib: str,
+        program_lib: str | None,
         transpiler_lib: str,
-        transpiler_options: dict | None,
+        transpiler_options: dict[str, Any] | None,
         device: Any | None,  # noqa: ANN401
         device_lib: str | None,
     ) -> TranspileResult:
@@ -99,23 +109,35 @@ class TranspilerDispatcher:
         if program is None:
             msg = "No program specified. Please specify a valid quantum circuit."
             raise ProgramNotSpecifiedError(msg)
-        if program_lib is None:
-            msg = "No program library specified. Please specify a program format "
-            "('qiskit', 'openqasm3', 'tket', etc.)."
-            raise ProgramLibNotSpecifiedError(msg)
         if transpiler_lib is None:
-            msg = "No transpiler library specified. Please specify a transpiler to use "
-            "('qiskit', 'tket', etc.)."
+            msg = "No transpiler library specified. Please specify a transpiler to use."
             raise TranspilerLibNotSpecifiedError(msg)
-        if device_lib is not None and device is None:
-            msg = "Device library is specified but no device is specified. "
-            "Please specify a device."
+
+        detected_program_lib = (
+            self._detect_program_lib(program) if program_lib is None else program_lib
+        )
+        if detected_program_lib is None:
+            msg = (
+                "No program library specified or detected. "
+                "Please specify a program format."
+            )
+            raise ProgramLibNotSpecifiedError(msg)
+
+        detected_device_lib = (
+            self._detect_device_lib(device) if device_lib is None else device_lib
+        )
+        if detected_device_lib is not None and device is None:
+            msg = "Device library is specified but no device is specified."
             raise DeviceNotSpecifiedError(msg)
 
         transpiler = self._transpiler_manager.fetch_transpiler(transpiler_lib)
 
-        converted_program = self._convert_program(program, program_lib, transpiler_lib)
-        converted_device = self._convert_device(device, device_lib, transpiler_lib)
+        converted_program = self._convert_program(
+            program, detected_program_lib, transpiler_lib
+        )
+        converted_device = self._convert_device(
+            device, detected_device_lib, transpiler_lib
+        )
 
         transpile_result = transpiler.transpile(
             converted_program,
@@ -126,10 +148,15 @@ class TranspilerDispatcher:
         transpile_result.transpiled_program = self._convert_program(
             transpile_result.transpiled_program,
             transpiler_lib,
-            program_lib,
+            detected_program_lib,
         )
-
         return transpile_result
+
+    def _detect_program_lib(self, program: Any) -> str | None:  # noqa: ANN401
+        return self._program_type_manager.detect_lib(program)
+
+    def _detect_device_lib(self, device: Any) -> str | None:  # noqa: ANN401
+        return self._device_type_manager.detect_lib(device)
 
     def _convert_program(self, program: Any, from_lib: str, to_lib: Any) -> Any:  # noqa: ANN401
         if self._program_converter_manager.has_converter(from_lib, to_lib):

--- a/tests/tranqu/test_device_type_manager.py
+++ b/tests/tranqu/test_device_type_manager.py
@@ -1,0 +1,47 @@
+from tranqu.device_type_manager import DeviceTypeManager
+
+
+class DummyDevice:
+    """Dummy device class for testing"""
+
+
+class TestDeviceTypeManager:
+    def setup_method(self):
+        self.manager = DeviceTypeManager()
+
+    def test_register_type(self):
+        self.manager.register_type("dummy", DummyDevice)
+        device = DummyDevice()
+
+        result = self.manager.detect_lib(device)
+
+        assert result == "dummy"
+
+    def test_detect_lib_returns_none_for_unregistered_type(self):
+        device = DummyDevice()
+
+        result = self.manager.detect_lib(device)
+
+        assert result is None
+
+    def test_detect_lib_with_multiple_registrations(self):
+        class AnotherDummyDevice:
+            pass
+
+        self.manager.register_type("dummy1", DummyDevice)
+        self.manager.register_type("dummy2", AnotherDummyDevice)
+
+        device1 = DummyDevice()
+        device2 = AnotherDummyDevice()
+
+        assert self.manager.detect_lib(device1) == "dummy1"
+        assert self.manager.detect_lib(device2) == "dummy2"
+
+    def test_register_type_multiple_times(self):
+        self.manager.register_type("dummy", DummyDevice)
+        self.manager.register_type("another_dummy", DummyDevice)
+
+        device = DummyDevice()
+
+        # The last registered library identifier is returned
+        assert self.manager.detect_lib(device) == "another_dummy"

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -1,4 +1,3 @@
-
 from tranqu.program_type_manager import ProgramTypeManager
 
 

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tranqu.program_type_manager import ProgramLibNotFoundError, ProgramTypeManager
+
+
+class DummyProgram:
+    """Dummy program class for testing"""
+
+
+class TestProgramTypeManager:
+    def setup_method(self):
+        self.manager = ProgramTypeManager()
+
+    def test_register_type(self):
+        self.manager.register_type("dummy", DummyProgram)
+        program = DummyProgram()
+
+        result = self.manager.detect_lib(program)
+
+        assert result == "dummy"
+
+    def test_detect_lib_raises_error_for_unregistered_type(self):
+        program = DummyProgram()
+
+        with pytest.raises(
+            ProgramLibNotFoundError,
+            match=(
+                "Could not detect program library. Please either "
+                "specify program_lib or register the program type "
+                "using register_program_type()."
+            ),
+        ):
+            self.manager.detect_lib(program)
+
+    def test_detect_lib_with_multiple_registrations(self):
+        class AnotherDummyProgram:
+            pass
+
+        self.manager.register_type("dummy1", DummyProgram)
+        self.manager.register_type("dummy2", AnotherDummyProgram)
+
+        program1 = DummyProgram()
+        program2 = AnotherDummyProgram()
+
+        assert self.manager.detect_lib(program1) == "dummy1"
+        assert self.manager.detect_lib(program2) == "dummy2"
+
+    def test_register_type_multiple_times(self):
+        self.manager.register_type("dummy", DummyProgram)
+        self.manager.register_type("another_dummy", DummyProgram)
+
+        program = DummyProgram()
+
+        # The last registered library identifier is returned
+        assert self.manager.detect_lib(program) == "another_dummy"

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -1,6 +1,5 @@
-import pytest
 
-from tranqu.program_type_manager import ProgramLibNotFoundError, ProgramTypeManager
+from tranqu.program_type_manager import ProgramTypeManager
 
 
 class DummyProgram:
@@ -19,18 +18,12 @@ class TestProgramTypeManager:
 
         assert result == "dummy"
 
-    def test_detect_lib_raises_error_for_unregistered_type(self):
+    def test_detect_lib_returns_none_for_unregistered_type(self):
         program = DummyProgram()
 
-        with pytest.raises(
-            ProgramLibNotFoundError,
-            match=(
-                "Could not detect program library. Please either "
-                "specify program_lib or register the program type "
-                "using register_program_type()."
-            ),
-        ):
-            self.manager.detect_lib(program)
+        result = self.manager.detect_lib(program)
+
+        assert result is None
 
     def test_detect_lib_with_multiple_registrations(self):
         class AnotherDummyProgram:

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -3,7 +3,9 @@
 import re
 
 import pytest
+from pytket import Circuit as TketCircuit
 from qiskit import QuantumCircuit as QiskitCircuit
+from qiskit_ibm_runtime.fake_provider import FakeSantiagoV2
 
 from tranqu import Tranqu, __version__
 from tranqu.program_converter import ProgramConverter
@@ -168,3 +170,37 @@ c[1] = measure $2;
                 device=device,
                 device_lib="custom",
             )
+
+    def test_detect_program_lib(self):
+        tranqu = Tranqu()
+        circuit = QiskitCircuit(1)
+
+        result = tranqu.transpile(
+            circuit,
+            transpiler_lib="qiskit",
+        )
+
+        assert isinstance(result.transpiled_program, QiskitCircuit)
+
+    def test_detect_program_lib_with_tket_circuit(self):
+        tranqu = Tranqu()
+        circuit = TketCircuit(1)
+
+        result = tranqu.transpile(
+            circuit,
+            transpiler_lib="qiskit",
+        )
+
+        assert isinstance(result.transpiled_program, TketCircuit)
+
+    def test_detect_device_lib(self):
+        tranqu = Tranqu()
+        device = FakeSantiagoV2()
+
+        result = tranqu.transpile(
+            QiskitCircuit(1),
+            transpiler_lib="qiskit",
+            device=device,
+        )
+
+        assert isinstance(result.transpiled_program, QiskitCircuit)

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -11,7 +11,11 @@ from tranqu import Tranqu, __version__
 from tranqu.program_converter import ProgramConverter
 from tranqu.transpiler_dispatcher import (
     DeviceConversionPathNotFoundError,
+    DeviceNotSpecifiedError,
     ProgramConversionPathNotFoundError,
+    ProgramLibNotFoundError,
+    ProgramNotSpecifiedError,
+    TranspilerLibNotSpecifiedError,
 )
 
 
@@ -204,3 +208,61 @@ c[1] = measure $2;
         )
 
         assert isinstance(result.transpiled_program, QiskitCircuit)
+
+    def test_program_not_specified(self):
+        tranqu = Tranqu()
+
+        with pytest.raises(
+            ProgramNotSpecifiedError,
+            match="No program specified.",
+        ):
+            tranqu.transpile(
+                program=None,
+                transpiler_lib="qiskit",
+            )
+
+    def test_transpiler_lib_not_specified(self):
+        tranqu = Tranqu()
+        circuit = QiskitCircuit(1)
+
+        with pytest.raises(
+            TranspilerLibNotSpecifiedError,
+            match="No transpiler library specified.",
+        ):
+            tranqu.transpile(
+                circuit,
+                program_lib="qiskit",
+                transpiler_lib=None,
+            )
+
+    def test_program_lib_not_found(self):
+        tranqu = Tranqu()
+
+        class UnknownCircuit:
+            pass
+
+        circuit = UnknownCircuit()
+
+        with pytest.raises(
+            ProgramLibNotFoundError, match="Could not detect program library."
+        ):
+            tranqu.transpile(
+                circuit,
+                transpiler_lib="qiskit",
+            )
+
+    def test_device_not_specified_error(self):
+        tranqu = Tranqu()
+        circuit = QiskitCircuit(1)
+
+        with pytest.raises(
+            DeviceNotSpecifiedError,
+            match="Device library is specified but no device is specified.",
+        ):
+            tranqu.transpile(
+                circuit,
+                program_lib="qiskit",
+                transpiler_lib="qiskit",
+                device=None,
+                device_lib="qiskit",
+            )

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -48,7 +48,9 @@ class TestTranqu:
             )
             circuit = EnigmaCircuit()
 
-            result = tranqu.transpile(circuit, "enigma", "qiskit")
+            result = tranqu.transpile(
+                circuit, program_lib="enigma", transpiler_lib="qiskit"
+            )
 
             assert isinstance(result.transpiled_program, EnigmaCircuit)
 
@@ -148,7 +150,7 @@ c[1] = measure $2;
             ProgramConversionPathNotFoundError,
             match="No ProgramConverter path found to convert from enigma to qiskit",
         ):
-            tranqu.transpile(circuit, "enigma", "qiskit")
+            tranqu.transpile(circuit, program_lib="enigma", transpiler_lib="qiskit")
 
     def test_device_conversion_path_not_found(self):
         tranqu = Tranqu()

--- a/tests/tranqu/transpiler/test_transpiler_manager.py
+++ b/tests/tranqu/transpiler/test_transpiler_manager.py
@@ -51,7 +51,9 @@ class TestTranspilerManager:
         tranqu.register_transpiler("nop", NopTranspiler())
         tranqu.register_program_converter("nop", "openqasm3", NopToQasm3Converter())
         tranqu.register_program_converter("openqasm3", "nop", Qasm3ToNopConverter())
-        result = tranqu.transpile(qasm_code, "openqasm3", "nop")
+        result = tranqu.transpile(
+            qasm_code, program_lib="openqasm3", transpiler_lib="nop"
+        )
 
         assert result.transpiled_program.strip() == qasm_code.strip()
 


### PR DESCRIPTION
## ✍ Description
This PR improves the usability of Tranqu's transpile() method by adding automatic type detection capabilities.

### Key Changes
**Added Program Format Auto-detection**
- Implemented new ProgramTypeManager class to automatically detect library from program type
- Made program_lib argument optional
- Example: When passing a Qiskit QuantumCircuit object, it's automatically recognized as "qiskit"

**Added Device Format Auto-detection**
- Implemented new DeviceTypeManager class to automatically detect library from device type
- Made device_lib argument optional
- Example: When passing a Qiskit BackendV2 object, it's automatically recognized as "qiskit"

before:
```python
result = tranqu.transpile(
    program=circuit,
    program_lib="qiskit",  # explicit specification required
    transpiler_lib="qiskit",
    device=backend,
    device_lib="qiskit"  # explicit specification required
)
```

after:
```
result = tranqu.transpile(
    program=circuit,  # QiskitCircuit object
    transpiler_lib="qiskit",
    device=backend  # BackendV2 object
)
```