### PR TITLE
default transpiler lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,26 +65,27 @@ include = [
 ]
 lint.select = ["ALL"]
 lint.ignore = [
+  "COM812",
   "CPY001",
   "D100",
-  "D107",
   "D104",
+  "D107",
   "D203",
   "D213",
-  "COM812",
   "ISC001",
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
-  "D",
   "ANN201",
+  "ANN205",
   "ANN401",
-  "S101",
   "CPY001",
+  "D",
+  "PLC1901",
   "PLR2004",
   "PLR6301",
-  "ANN205",
+  "S101",
 ]
 
 [tool.mypy]

--- a/src/tranqu/tranqu.py
+++ b/src/tranqu/tranqu.py
@@ -31,6 +31,7 @@ Example:
 Additionally, it is possible to incorporate user-defined transpilers.
 This module also provides a series of methods for this purpose.
 
+- `register_default_transpiler_lib()`: Registers the default transpiler library.
 - `register_transpiler()`: Registers a custom transpiler to Tranqu.
 - `register_program_converter()`: Registers a converter (`ProgramConverter`)
     for quantum circuit programs. When registering a custom transpiler,
@@ -131,8 +132,8 @@ class Tranqu:
     def transpile(  # noqa: PLR0913
         self,
         program: Any,  # noqa: ANN401
-        transpiler_lib: str,
         program_lib: str | None = None,
+        transpiler_lib: str | None = None,
         *,
         transpiler_options: dict[str, Any] | None = None,
         device: Any | None = None,  # noqa: ANN401
@@ -142,9 +143,9 @@ class Tranqu:
 
         Args:
             program (Any): The program to be transformed.
-            transpiler_lib (str): The name of the transpiler to be used.
             program_lib (str | None): The library or format of the program. If None,
                 will attempt to detect based on program type.
+            transpiler_lib (str | None): The name of the transpiler to be used.
             transpiler_options (dict[str, Any]): Options passed to the transpiler.
             device (Any | None): Information about the device on which
                 the program will be executed.
@@ -170,6 +171,19 @@ class Tranqu:
             device,
             device_lib,
         )
+
+    def register_default_transpiler_lib(
+        self,
+        default_transpiler_lib: str,
+    ) -> None:
+        """Register the default transpiler library.
+
+        Args:
+            default_transpiler_lib (str): The name of the default transpiler library
+                to register.
+
+        """
+        self._transpiler_manager.register_default_transpiler_lib(default_transpiler_lib)
 
     def register_transpiler(
         self,

--- a/src/tranqu/transpiler/__init__.py
+++ b/src/tranqu/transpiler/__init__.py
@@ -1,12 +1,14 @@
 from .qiskit_transpiler import QiskitTranspiler
 from .transpiler import Transpiler
 from .transpiler_manager import (
+    DefaultTranspilerLibAlreadyRegisteredError,
     TranspilerAlreadyRegisteredError,
     TranspilerManager,
     TranspilerNotFoundError,
 )
 
 __all__ = [
+    "DefaultTranspilerLibAlreadyRegisteredError",
     "QiskitTranspiler",
     "Transpiler",
     "TranspilerAlreadyRegisteredError",

--- a/src/tranqu/transpiler/transpiler_manager.py
+++ b/src/tranqu/transpiler/transpiler_manager.py
@@ -54,8 +54,8 @@ class TranspilerManager:
 
         self._default_transpiler_lib = default_transpiler_lib
 
-    def fetch_default_transpiler_lib(self) -> str | None:
-        """Fetch the default transpiler library.
+    def get_default_transpiler_lib(self) -> str | None:
+        """Get the default transpiler library.
 
         Returns:
             str: The default transpiler library.

--- a/src/tranqu/transpiler/transpiler_manager.py
+++ b/src/tranqu/transpiler/transpiler_manager.py
@@ -7,6 +7,10 @@ class TranspilerError(TranquError):
     """Base exception for transpiler-related errors."""
 
 
+class DefaultTranspilerLibAlreadyRegisteredError(TranspilerError):
+    """Raised when a default transpiler_lib is already registered."""
+
+
 class TranspilerAlreadyRegisteredError(TranspilerError):
     """Raised when attempting to register a transpiler that already exists."""
 
@@ -24,6 +28,40 @@ class TranspilerManager:
 
     def __init__(self) -> None:
         self._transpilers: dict[str, Any] = {}
+        self._default_transpiler_lib: str | None = None
+
+    def register_default_transpiler_lib(
+        self,
+        default_transpiler_lib: str,
+    ) -> None:
+        """Register the default transpiler library.
+
+        Args:
+            default_transpiler_lib (str): The name of the default transpiler library
+                to register.
+
+        Raises:
+            DefaultTranspilerLibAlreadyRegisteredError: If a transpiler
+                with the same name is already registered.
+
+        """
+        if self._default_transpiler_lib is not None:
+            msg = (
+                f"Default transpiler_lib '{self._default_transpiler_lib}' "
+                "is already registered."
+            )
+            raise DefaultTranspilerLibAlreadyRegisteredError(msg)
+
+        self._default_transpiler_lib = default_transpiler_lib
+
+    def fetch_default_transpiler_lib(self) -> str | None:
+        """Fetch the default transpiler library.
+
+        Returns:
+            str: The default transpiler library.
+
+        """
+        return self._default_transpiler_lib
 
     def register_transpiler(
         self,

--- a/src/tranqu/transpiler_dispatcher.py
+++ b/src/tranqu/transpiler_dispatcher.py
@@ -82,7 +82,7 @@ class TranspilerDispatcher:
         self,
         program: Any,  # noqa: ANN401
         program_lib: str | None,
-        transpiler_lib: str,
+        transpiler_lib: str | None,
         transpiler_options: dict[str, Any] | None,
         device: Any | None,  # noqa: ANN401
         device_lib: str | None,
@@ -93,7 +93,7 @@ class TranspilerDispatcher:
             program (Any): The quantum circuit to be transpiled
             program_lib (str): Name of the library for the input circuit
                 (e.g., "qiskit")
-            transpiler_lib (str): Name of the transpiler library to use
+            transpiler_lib (str | None): Name of the transpiler library to use
             transpiler_options (dict | None): Options to be passed to the transpiler
             device (Any | None): Target device (optional)
             device_lib (str | None): Name of the device library (optional)
@@ -114,8 +114,13 @@ class TranspilerDispatcher:
             msg = "No program specified. Please specify a valid quantum circuit."
             raise ProgramNotSpecifiedError(msg)
         if transpiler_lib is None:
-            msg = "No transpiler library specified. Please specify a transpiler to use."
-            raise TranspilerLibNotSpecifiedError(msg)
+            transpiler_lib = self._transpiler_manager.fetch_default_transpiler_lib()
+            if transpiler_lib is None:
+                msg = (
+                    "No transpiler library specified."
+                    " Please specify a transpiler to use."
+                )
+                raise TranspilerLibNotSpecifiedError(msg)
 
         detected_program_lib = (
             self._detect_program_lib(program) if program_lib is None else program_lib

--- a/src/tranqu/transpiler_dispatcher.py
+++ b/src/tranqu/transpiler_dispatcher.py
@@ -114,7 +114,7 @@ class TranspilerDispatcher:
             msg = "No program specified. Please specify a valid quantum circuit."
             raise ProgramNotSpecifiedError(msg)
         if transpiler_lib is None:
-            transpiler_lib = self._transpiler_manager.fetch_default_transpiler_lib()
+            transpiler_lib = self._transpiler_manager.get_default_transpiler_lib()
             if transpiler_lib is None:
                 msg = (
                     "No transpiler library specified."

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -9,6 +9,7 @@ from qiskit_ibm_runtime.fake_provider import FakeSantiagoV2
 
 from tranqu import Tranqu, __version__
 from tranqu.program_converter import ProgramConverter
+from tranqu.transpiler.transpiler_manager import TranspilerNotFoundError
 from tranqu.transpiler_dispatcher import (
     DeviceConversionPathNotFoundError,
     DeviceNotSpecifiedError,
@@ -38,16 +39,6 @@ class TestTranqu:
         assert isinstance(__version__, str)
         # Check if the version string follows semantic versioning format
         assert re.match(r"^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$", __version__)
-
-    def test_default_transpiler_lib_not_found(self):
-        tranqu = Tranqu()
-        circuit = QiskitCircuit(1)
-
-        with pytest.raises(TranspilerLibNotSpecifiedError):
-            tranqu.transpile(
-                circuit,
-                program_lib="qiskit",
-            )
 
     class TestCustomProgramsAndConverters:
         def test_transpile_custom_circuit_with_qiskit_transpiler(self):
@@ -243,6 +234,20 @@ c[1] = measure $2;
                 circuit,
                 program_lib="qiskit",
                 transpiler_lib=None,
+            )
+
+    def test_transpiler_lib_not_exist(self):
+        tranqu = Tranqu()
+        tranqu.register_default_transpiler_lib("nop")
+        circuit = QiskitCircuit(1)
+
+        with pytest.raises(
+            TranspilerNotFoundError,
+            match="Unknown transpiler: nop",
+        ):
+            tranqu.transpile(
+                circuit,
+                program_lib="qiskit",
             )
 
     def test_program_lib_not_found(self):

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -39,6 +39,16 @@ class TestTranqu:
         # Check if the version string follows semantic versioning format
         assert re.match(r"^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$", __version__)
 
+    def test_default_transpiler_lib_not_found(self):
+        tranqu = Tranqu()
+        circuit = QiskitCircuit(1)
+
+        with pytest.raises(TranspilerLibNotSpecifiedError):
+            tranqu.transpile(
+                circuit,
+                program_lib="qiskit",
+            )
+
     class TestCustomProgramsAndConverters:
         def test_transpile_custom_circuit_with_qiskit_transpiler(self):
             tranqu = Tranqu()

--- a/tests/tranqu/transpiler/test_transpiler_manager.py
+++ b/tests/tranqu/transpiler/test_transpiler_manager.py
@@ -6,6 +6,7 @@ from tranqu import Tranqu
 from tranqu.program_converter import ProgramConverter
 from tranqu.transpile_result import TranspileResult
 from tranqu.transpiler import (
+    DefaultTranspilerLibAlreadyRegisteredError,
     Transpiler,
     TranspilerAlreadyRegisteredError,
     TranspilerManager,
@@ -56,6 +57,21 @@ class TestTranspilerManager:
         )
 
         assert result.transpiled_program.strip() == qasm_code.strip()
+
+    def test_register_default_transpiler_lib(self):
+        manager = TranspilerManager()
+        assert manager.fetch_default_transpiler_lib() == None  # noqa: E711
+
+        manager.register_default_transpiler_lib("nop")
+        assert manager.fetch_default_transpiler_lib() == "nop"
+
+    def test_register_default_transpiler_lib_already_registered(self):
+        manager = TranspilerManager()
+
+        manager.register_default_transpiler_lib("nop")
+
+        with pytest.raises(DefaultTranspilerLibAlreadyRegisteredError):
+            manager.register_default_transpiler_lib("nop")
 
     def test_register_transpiler_already_registered(self):
         manager = TranspilerManager()

--- a/tests/tranqu/transpiler/test_transpiler_manager.py
+++ b/tests/tranqu/transpiler/test_transpiler_manager.py
@@ -60,10 +60,10 @@ class TestTranspilerManager:
 
     def test_register_default_transpiler_lib(self):
         manager = TranspilerManager()
-        assert manager.fetch_default_transpiler_lib() == None  # noqa: E711
+        assert manager.get_default_transpiler_lib() == None  # noqa: E711
 
         manager.register_default_transpiler_lib("nop")
-        assert manager.fetch_default_transpiler_lib() == "nop"
+        assert manager.get_default_transpiler_lib() == "nop"
 
     def test_register_default_transpiler_lib_already_registered(self):
         manager = TranspilerManager()


### PR DESCRIPTION
## ✍ Description

- The register_default transpiler_lib function has been added to the Tranqu class. If default transpiler_lib is set, transpiler_lib can be omitted.
- The ruff code written in pyproject.toml is sorted in alphabetical order.