### PR TITLE
feat: add allow_override parameter to registration methods

### DIFF
--- a/src/tranqu/device_converter/__init__.py
+++ b/src/tranqu/device_converter/__init__.py
@@ -3,6 +3,7 @@ from .device_converter_manager import (
     DeviceConverterAlreadyRegisteredError,
     DeviceConverterError,
     DeviceConverterManager,
+    DeviceConverterNotFoundError,
 )
 from .oqtopus_to_qiskit_device_converter import OqtoqusToQiskitDeviceConverter
 from .pass_through_device_converter import PassThroughDeviceConverter
@@ -13,6 +14,7 @@ __all__ = [
     "DeviceConverterAlreadyRegisteredError",
     "DeviceConverterError",
     "DeviceConverterManager",
+    "DeviceConverterNotFoundError",
     "OqtoqusToQiskitDeviceConverter",
     "PassThroughDeviceConverter",
     "QiskitDevice",

--- a/src/tranqu/device_converter/device_converter_manager.py
+++ b/src/tranqu/device_converter/device_converter_manager.py
@@ -78,6 +78,8 @@ class DeviceConverterManager:
         from_lib: str,
         to_lib: str,
         converter: DeviceConverter,
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a converter between the specified devices.
 
@@ -85,15 +87,21 @@ class DeviceConverterManager:
             from_lib (str): The name of the source device
             to_lib (str): The name of the target device
             converter (DeviceConverter): The converter instance to register
+            allow_override (bool): When False, prevents overwriting existing
+              registrations. Defaults to False.
 
         Raises:
             DeviceConverterAlreadyRegisteredError:
                 Raises if trying to re-register an already registered converter
+                and allow_override is False.
 
         """
         key = (from_lib, to_lib)
-        if key in self._converters:
-            msg = f"Converter already registered for conversion from {from_lib} to {to_lib}."  # noqa: E501
+        if not allow_override and key in self._converters:
+            msg = (
+                f"Converter already registered for conversion from {from_lib} "
+                f"to {to_lib}."
+            )
             raise DeviceConverterAlreadyRegisteredError(msg)
 
         self._converters[key] = converter

--- a/src/tranqu/device_type_manager.py
+++ b/src/tranqu/device_type_manager.py
@@ -7,20 +7,39 @@ class DeviceLibNotFoundError(TranquError):
     """Error raised when device library cannot be detected."""
 
 
+class DeviceLibraryAlreadyRegisteredError(TranquError):
+    """Raised when attempting to register a device library that already exists."""
+
+
 class DeviceTypeManager:
     """Class that manages mapping between device types and library identifiers."""
 
     def __init__(self) -> None:
-        self._type_registry: dict[type, str] = {}
+        self._type_registry: dict[type[Any], str] = {}
 
-    def register_type(self, device_lib: str, device_type: type) -> None:
+    def register_type(
+        self, device_lib: str, device_type: type[Any], *, allow_override: bool = False
+    ) -> None:
         """Register a device type and its library identifier.
 
         Args:
             device_lib (str): Library identifier (e.g., "qiskit", "oqtopus")
             device_type (Type): Device type class to register
+            allow_override (bool): When False, prevents overwriting existing
+              registrations. Defaults to False.
+
+        Raises:
+            DeviceLibraryAlreadyRegisteredError: If the library is already registered
+                and allow_override is False.
 
         """
+        if not allow_override and device_lib in self._type_registry.values():
+            msg = (
+                f"Library '{device_lib}' is already registered. "
+                "Use allow_override=True to force registration."
+            )
+            raise DeviceLibraryAlreadyRegisteredError(msg)
+
         self._type_registry[device_type] = device_lib
 
     def detect_lib(self, device: Any) -> str | None:  # noqa: ANN401

--- a/src/tranqu/program_converter/program_converter_manager.py
+++ b/src/tranqu/program_converter/program_converter_manager.py
@@ -78,6 +78,8 @@ class ProgramConverterManager:
         from_lib: str,
         to_lib: str,
         converter: ProgramConverter,
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a converter between the specified programs.
 
@@ -85,15 +87,21 @@ class ProgramConverterManager:
             from_lib (str): The name of the source program.
             to_lib (str): The name of the target program.
             converter (ProgramConverter): The converter instance to register.
+            allow_override (bool): When False, prevents overwriting existing
+              registrations. Defaults to False.
 
         Raises:
             ProgramConverterAlreadyRegisteredError:
-                Raised when attempting to re-register an already registered converter.
+                Raised when attempting to re-register an already registered converter
+                and allow_override is False.
 
         """
         key = (from_lib, to_lib)
-        if key in self._converters:
-            msg = f"Converter already registered for conversion from {from_lib} to {to_lib}."  # noqa: E501
+        if not allow_override and key in self._converters:
+            msg = (
+                f"Converter already registered for conversion from {from_lib} "
+                f"to {to_lib}."
+            )
             raise ProgramConverterAlreadyRegisteredError(msg)
 
         self._converters[key] = converter

--- a/src/tranqu/program_type_manager.py
+++ b/src/tranqu/program_type_manager.py
@@ -1,30 +1,55 @@
 from typing import Any
 
+from .tranqu_error import TranquError
+
+
+class ProgramTypeError(TranquError):
+    """Base exception for program type-related errors."""
+
+
+class ProgramLibraryAlreadyRegisteredError(ProgramTypeError):
+    """Raised when attempting to register a program library that already exists."""
+
 
 class ProgramTypeManager:
     """Class that manages the mapping between program types and library identifiers."""
 
     def __init__(self) -> None:
-        self._type_registry: dict[type, str] = {}
+        self._type_registry: dict[type[Any], str] = {}
 
-    def register_type(self, program_lib: str, program_type: type) -> None:
-        """Register a program type and its library identifier.
+    def register_type(
+        self, program_lib: str, program_type: type[Any], *, allow_override: bool = False
+    ) -> None:
+        """Register a program type with its corresponding library identifier.
 
         Args:
-            program_lib (str): Library identifier (e.g., "qiskit", "tket")
-            program_type (Type): Program type class to register
+            program_lib: Library identifier (e.g., "qiskit", "tket")
+            program_type: Type of the program to register
+            allow_override: When False, prevents overwriting existing registrations.
+                          Defaults to False.
+
+        Raises:
+            ProgramLibraryAlreadyRegisteredError: If the library is already registered
+                and allow_override is False.
 
         """
+        if not allow_override and program_lib in self._type_registry.values():
+            msg = (
+                f"Library '{program_lib}' is already registered. "
+                "Use allow_override=True to force registration."
+            )
+            raise ProgramLibraryAlreadyRegisteredError(msg)
+
         self._type_registry[program_type] = program_lib
 
-    def detect_lib(self, program: Any) -> str | None:  # noqa: ANN401
-        """Detect the library based on the program type.
+    def detect_lib(self, program: type[Any]) -> str | None:
+        """Detect the library identifier for a given program instance.
 
         Args:
-            program (Any): Program to inspect
+            program: Program instance to inspect
 
         Returns:
-            str | None: Library identifier for registered program type, None otherwise
+            The library identifier if the program type is registered, None otherwise.
 
         """
         for program_type, lib in self._type_registry.items():

--- a/src/tranqu/program_type_manager.py
+++ b/src/tranqu/program_type_manager.py
@@ -23,14 +23,14 @@ class ProgramTypeManager:
         """Register a program type with its corresponding library identifier.
 
         Args:
-            program_lib: Library identifier (e.g., "qiskit", "tket")
-            program_type: Type of the program to register
-            allow_override: When False, prevents overwriting existing registrations.
-                          Defaults to False.
+            program_lib (str): Library identifier (e.g., "qiskit", "tket")
+            program_type (type[Any]): Type of the program to register
+            allow_override (bool): When False, prevents overwriting existing
+              registrations. Defaults to False.
 
         Raises:
-            ProgramLibraryAlreadyRegisteredError: If the library is already registered
-                and allow_override is False.
+            ProgramLibraryAlreadyRegisteredError: If the library is already
+              registered and allow_override is False.
 
         """
         if not allow_override and program_lib in self._type_registry.values():
@@ -42,11 +42,11 @@ class ProgramTypeManager:
 
         self._type_registry[program_type] = program_lib
 
-    def detect_lib(self, program: type[Any]) -> str | None:
+    def detect_lib(self, program: Any) -> str | None:  # noqa: ANN401
         """Detect the library identifier for a given program instance.
 
         Args:
-            program: Program instance to inspect
+            program (Any): Program instance to inspect
 
         Returns:
             The library identifier if the program type is registered, None otherwise.

--- a/src/tranqu/tranqu.py
+++ b/src/tranqu/tranqu.py
@@ -175,6 +175,8 @@ class Tranqu:
         self,
         transpiler_lib: str,
         transpiler: Any,  # noqa: ANN401
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a transpiler for optimizing quantum circuits.
 
@@ -183,15 +185,22 @@ class Tranqu:
         Args:
             transpiler_lib (str): The name of the transpiler library.
             transpiler (Any): The transpiler to be registered.
+            allow_override: When True, allows overwriting of existing transpilers
 
         """
-        self._transpiler_manager.register_transpiler(transpiler_lib, transpiler)
+        self._transpiler_manager.register_transpiler(
+            transpiler_lib,
+            transpiler,
+            allow_override=allow_override,
+        )
 
     def register_program_converter(
         self,
         from_program_lib: str,
         to_program_lib: str,
         converter: ProgramConverter,
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a program converter.
 
@@ -205,6 +214,8 @@ class Tranqu:
                 the converter to be registered.
             converter (ProgramConverter): The program converter to be registered
                 (subclass of ProgramConverter).
+            allow_override: When True, allows overwriting of existing converters.
+                Defaults to False.
 
         Examples:
             To register a converter that transforms from "foo" to "bar", you can call:
@@ -218,6 +229,7 @@ class Tranqu:
             from_program_lib,
             to_program_lib,
             converter,
+            allow_override=allow_override,
         )
 
     def register_device_converter(
@@ -225,6 +237,8 @@ class Tranqu:
         from_device_lib: str,
         to_device_lib: str,
         converter: DeviceConverter,
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a device converter.
 
@@ -238,6 +252,8 @@ class Tranqu:
                 the converter to be registered.
             converter (DeviceConverter): The device converter to be registered
                 (subclass of DeviceConverter).
+            allow_override (bool): When True, allows overwriting of existing converters.
+                Defaults to False.
 
         Examples:
             To register a converter that transforms from "foo" to "bar", you would call:
@@ -249,9 +265,16 @@ class Tranqu:
             from_device_lib,
             to_device_lib,
             converter,
+            allow_override=allow_override,
         )
 
-    def register_program_type(self, program_lib: str, program_type: type) -> None:
+    def register_program_type(
+        self,
+        program_lib: str,
+        program_type: type,
+        *,
+        allow_override: bool = False,
+    ) -> None:
         """Register a mapping between a program type and its library identifier.
 
         This method allows automatic detection of the program library based on the
@@ -261,15 +284,27 @@ class Tranqu:
             program_lib (str): The identifier for the program library
               (e.g., "qiskit", "tket")
             program_type (type): The type class to be associated with the library
+            allow_override (bool): When True, allows overwriting of existing type
+                registrations. Defaults to False.
 
         Examples:
             To register Qiskit's QuantumCircuit type:
                 tranqu.register_program_type("qiskit", QuantumCircuit)
 
         """
-        self._program_type_manager.register_type(program_lib, program_type)
+        self._program_type_manager.register_type(
+            program_lib,
+            program_type,
+            allow_override=allow_override,
+        )
 
-    def register_device_type(self, device_lib: str, device_type: type) -> None:
+    def register_device_type(
+        self,
+        device_lib: str,
+        device_type: type,
+        *,
+        allow_override: bool = False,
+    ) -> None:
         """Register a mapping between a device type and its library identifier.
 
         This method enables automatic detection of the device library based on
@@ -279,13 +314,19 @@ class Tranqu:
             device_lib (str): The identifier for the device library
               (e.g., "qiskit", "oqtopus")
             device_type (type): The type class to be associated with the library
+            allow_override (bool): When True, allows overwriting of existing type
+                registrations. Defaults to False.
 
         Examples:
             To register Qiskit's backend type:
                 tranqu.register_device_type("qiskit", BackendV2)
 
         """
-        self._device_type_manager.register_type(device_lib, device_type)
+        self._device_type_manager.register_type(
+            device_lib,
+            device_type,
+            allow_override=allow_override,
+        )
 
     def _register_builtin_program_converters(self) -> None:
         self.register_program_converter(

--- a/src/tranqu/transpiler/transpiler_manager.py
+++ b/src/tranqu/transpiler/transpiler_manager.py
@@ -29,19 +29,23 @@ class TranspilerManager:
         self,
         transpiler_lib: str,
         transpiler: Any,  # noqa: ANN401
+        *,
+        allow_override: bool = False,
     ) -> None:
         """Register a new transpiler.
 
         Args:
             transpiler_lib (str): The name of the transpiler library to register.
             transpiler (Any): An instance of the Transpiler to register.
+            allow_override (bool): When False, prevents overwriting existing
+              registrations. Defaults to False.
 
         Raises:
             TranspilerAlreadyRegisteredError: If a transpiler with the same name
-                is already registered.
+                is already registered and allow_override is False.
 
         """
-        if transpiler_lib in self._transpilers:
+        if not allow_override and transpiler_lib in self._transpilers:
             msg = f"Transpiler '{transpiler_lib}' is already registered."
             raise TranspilerAlreadyRegisteredError(msg)
 

--- a/tests/tranqu/device_converter/test_device_converter_manager.py
+++ b/tests/tranqu/device_converter/test_device_converter_manager.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+import pytest
+
+from tranqu.device_converter import (
+    DeviceConverter,
+    DeviceConverterAlreadyRegisteredError,
+    DeviceConverterManager,
+    DeviceConverterNotFoundError,
+    PassThroughDeviceConverter,
+)
+
+
+class DummyDeviceConverter(DeviceConverter):
+    def convert(self, device: Any) -> Any:
+        return device
+
+
+class TestDeviceConverterManager:
+    def setup_method(self):
+        self.manager = DeviceConverterManager()
+
+    def test_register_converter(self):
+        converter = DummyDeviceConverter()
+        self.manager.register_converter("lib1", "lib2", converter)
+
+        assert self.manager.has_converter("lib1", "lib2")
+
+    def test_register_converter_raises_error_when_already_registered(self):
+        converter = DummyDeviceConverter()
+        self.manager.register_converter("lib1", "lib2", converter)
+
+        with pytest.raises(
+            DeviceConverterAlreadyRegisteredError,
+            match="Converter already registered for conversion from lib1 to lib2.",
+        ):
+            self.manager.register_converter("lib1", "lib2", converter)
+
+    def test_register_converter_with_allow_override(self):
+        converter1 = DummyDeviceConverter()
+        converter2 = DummyDeviceConverter()
+
+        self.manager.register_converter("lib1", "lib2", converter1)
+        self.manager.register_converter("lib1", "lib2", converter2, allow_override=True)
+
+        assert self.manager.fetch_converter("lib1", "lib2") == converter2
+
+    def test_has_converter_returns_true_for_same_lib(self):
+        assert self.manager.has_converter("lib1", "lib1")
+
+    def test_has_converter_returns_false_for_unregistered_converter(self):
+        assert not self.manager.has_converter("lib1", "lib2")
+
+    def test_fetch_converter_returns_pass_through_for_same_lib(self):
+        converter = self.manager.fetch_converter("lib1", "lib1")
+        assert isinstance(converter, PassThroughDeviceConverter)
+
+    def test_fetch_converter_raises_error_when_not_found(self):
+        with pytest.raises(
+            DeviceConverterNotFoundError,
+            match="Converter not found for conversion from lib1 to lib2.",
+        ):
+            self.manager.fetch_converter("lib1", "lib2")

--- a/tests/tranqu/program_converter/test_program_converter_manager.py
+++ b/tests/tranqu/program_converter/test_program_converter_manager.py
@@ -58,3 +58,12 @@ class TestProgramConverterManager:
         converter = self.manager.fetch_converter("foo", "foo")
 
         assert isinstance(converter, PassThroughProgramConverter)
+
+    def test_register_converter_with_allow_override(self):
+        converter1 = TestFooBarConverter()
+        converter2 = BazToQuxConverter()
+
+        self.manager.register_converter("foo", "bar", converter1)
+        self.manager.register_converter("foo", "bar", converter2, allow_override=True)
+
+        assert self.manager.fetch_converter("foo", "bar") == converter2

--- a/tests/tranqu/test_device_type_manager.py
+++ b/tests/tranqu/test_device_type_manager.py
@@ -1,4 +1,9 @@
-from tranqu.device_type_manager import DeviceTypeManager
+import pytest
+
+from tranqu.device_type_manager import (
+    DeviceLibraryAlreadyRegisteredError,
+    DeviceTypeManager,
+)
 
 
 class DummyDevice:
@@ -45,3 +50,23 @@ class TestDeviceTypeManager:
 
         # The last registered library identifier is returned
         assert self.manager.detect_lib(device) == "another_dummy"
+
+    def test_register_type_raises_error_when_library_already_registered(self):
+        self.manager.register_type("dummy", DummyDevice)
+
+        with pytest.raises(
+            DeviceLibraryAlreadyRegisteredError,
+            match=(
+                "Library 'dummy' is already registered. "
+                "Use allow_override=True to force registration."
+            ),
+        ):
+            self.manager.register_type("dummy", DummyDevice)
+
+    def test_register_type_with_allow_override(self):
+        self.manager.register_type("dummy", DummyDevice)
+
+        self.manager.register_type("dummy", DummyDevice, allow_override=True)
+
+        device = DummyDevice()
+        assert self.manager.detect_lib(device) == "dummy"

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -57,11 +57,11 @@ class TestProgramTypeManager:
         class AnotherProgram:
             pass
 
-        with pytest.raises(ProgramLibraryAlreadyRegisteredError) as exc_info:
-            self.manager.register_type("dummy", AnotherProgram)
-
-        expected_msg = (
-            "Library 'dummy' is already registered. "
-            "Use allow_override=True to force registration."
-        )
-        assert str(exc_info.value) == expected_msg
+        with pytest.raises(
+            ProgramLibraryAlreadyRegisteredError,
+            match=(
+                "Library 'dummy' is already registered. "
+                "Use allow_override=True to force registration."
+            ),
+        ):
+            (self.manager.register_type("dummy", AnotherProgram),)

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -1,4 +1,9 @@
-from tranqu.program_type_manager import ProgramTypeManager
+import pytest
+
+from tranqu.program_type_manager import (
+    ProgramLibraryAlreadyRegisteredError,
+    ProgramTypeManager,
+)
 
 
 class DummyProgram:
@@ -45,3 +50,18 @@ class TestProgramTypeManager:
 
         # The last registered library identifier is returned
         assert self.manager.detect_lib(program) == "another_dummy"
+
+    def test_register_type_raises_error_when_lib_already_registered(self):
+        self.manager.register_type("dummy", DummyProgram)
+
+        class AnotherProgram:
+            pass
+
+        with pytest.raises(ProgramLibraryAlreadyRegisteredError) as exc_info:
+            self.manager.register_type("dummy", AnotherProgram)
+
+        expected_msg = (
+            "Library 'dummy' is already registered. "
+            "Use allow_override=True to force registration."
+        )
+        assert str(exc_info.value) == expected_msg


### PR DESCRIPTION
## ✍ Description
This PR adds the `allow_override` parameter to all registration methods in the `Tranqu` class to provide consistent control over registration overrides. The following methods have been updated:

- `register_program_converter`
- `register_device_converter`
- `register_program_type`
- `register_device_type`

Each method now accepts an optional `allow_override` parameter (defaults to `False`) that controls whether existing registrations can be overwritten.
