### PR TITLE
refactor: improve TranspilerDispatcher flow by extracting helper methods

### DIFF
--- a/src/tranqu/device_type_manager.py
+++ b/src/tranqu/device_type_manager.py
@@ -3,10 +3,6 @@ from typing import Any
 from .tranqu_error import TranquError
 
 
-class DeviceLibNotFoundError(TranquError):
-    """Error raised when device library cannot be detected."""
-
-
 class DeviceLibraryAlreadyRegisteredError(TranquError):
     """Raised when attempting to register a device library that already exists."""
 
@@ -42,8 +38,8 @@ class DeviceTypeManager:
 
         self._type_registry[device_type] = device_lib
 
-    def detect_lib(self, device: Any) -> str | None:  # noqa: ANN401
-        """Detect library based on device type.
+    def resolve_lib(self, device: Any) -> str | None:  # noqa: ANN401
+        """Resolve library based on device type.
 
         Args:
             device (Any): Device to inspect

--- a/src/tranqu/program_type_manager.py
+++ b/src/tranqu/program_type_manager.py
@@ -42,8 +42,8 @@ class ProgramTypeManager:
 
         self._type_registry[program_type] = program_lib
 
-    def detect_lib(self, program: Any) -> str | None:  # noqa: ANN401
-        """Detect the library identifier for a given program instance.
+    def resolve_lib(self, program: Any) -> str | None:  # noqa: ANN401
+        """Resolve the library identifier for a given program instance.
 
         Args:
             program (Any): Program instance to inspect

--- a/tests/tranqu/test_device_type_manager.py
+++ b/tests/tranqu/test_device_type_manager.py
@@ -10,49 +10,58 @@ class DummyDevice:
     """Dummy device class for testing"""
 
 
-class TestDeviceTypeManager:
-    def setup_method(self):
-        self.manager = DeviceTypeManager()
+@pytest.fixture
+def device_manager() -> DeviceTypeManager:
+    return DeviceTypeManager()
 
-    def test_register_type(self):
-        self.manager.register_type("dummy", DummyDevice)
+
+class TestDeviceTypeManager:
+    def test_register_type(self, device_manager: DeviceTypeManager) -> None:
+        device_manager.register_type("dummy", DummyDevice)
         device = DummyDevice()
 
-        result = self.manager.detect_lib(device)
+        result = device_manager.resolve_lib(device)
 
         assert result == "dummy"
 
-    def test_detect_lib_returns_none_for_unregistered_type(self):
+    def test_resolve_lib_returns_none_for_unregistered_type(
+        self, device_manager: DeviceTypeManager
+    ) -> None:
         device = DummyDevice()
 
-        result = self.manager.detect_lib(device)
+        result = device_manager.resolve_lib(device)
 
         assert result is None
 
-    def test_detect_lib_with_multiple_registrations(self):
+    def test_resolve_lib_with_multiple_registrations(
+        self, device_manager: DeviceTypeManager
+    ) -> None:
         class AnotherDummyDevice:
             pass
 
-        self.manager.register_type("dummy1", DummyDevice)
-        self.manager.register_type("dummy2", AnotherDummyDevice)
+        device_manager.register_type("dummy1", DummyDevice)
+        device_manager.register_type("dummy2", AnotherDummyDevice)
 
         device1 = DummyDevice()
         device2 = AnotherDummyDevice()
 
-        assert self.manager.detect_lib(device1) == "dummy1"
-        assert self.manager.detect_lib(device2) == "dummy2"
+        assert device_manager.resolve_lib(device1) == "dummy1"
+        assert device_manager.resolve_lib(device2) == "dummy2"
 
-    def test_register_type_multiple_times(self):
-        self.manager.register_type("dummy", DummyDevice)
-        self.manager.register_type("another_dummy", DummyDevice)
+    def test_register_type_multiple_times(
+        self, device_manager: DeviceTypeManager
+    ) -> None:
+        device_manager.register_type("dummy", DummyDevice)
+        device_manager.register_type("another_dummy", DummyDevice)
 
         device = DummyDevice()
 
-        # The last registered library identifier is returned
-        assert self.manager.detect_lib(device) == "another_dummy"
+        assert device_manager.resolve_lib(device) == "another_dummy"
 
-    def test_register_type_raises_error_when_library_already_registered(self):
-        self.manager.register_type("dummy", DummyDevice)
+    def test_register_type_raises_error_when_library_already_registered(
+        self, device_manager: DeviceTypeManager
+    ) -> None:
+        device_manager.register_type("dummy", DummyDevice)
 
         with pytest.raises(
             DeviceLibraryAlreadyRegisteredError,
@@ -61,12 +70,14 @@ class TestDeviceTypeManager:
                 "Use allow_override=True to force registration."
             ),
         ):
-            self.manager.register_type("dummy", DummyDevice)
+            device_manager.register_type("dummy", DummyDevice)
 
-    def test_register_type_with_allow_override(self):
-        self.manager.register_type("dummy", DummyDevice)
+    def test_register_type_with_allow_override(
+        self, device_manager: DeviceTypeManager
+    ) -> None:
+        device_manager.register_type("dummy", DummyDevice)
 
-        self.manager.register_type("dummy", DummyDevice, allow_override=True)
+        device_manager.register_type("dummy", DummyDevice, allow_override=True)
 
         device = DummyDevice()
-        assert self.manager.detect_lib(device) == "dummy"
+        assert device_manager.resolve_lib(device) == "dummy"

--- a/tests/tranqu/test_program_type_manager.py
+++ b/tests/tranqu/test_program_type_manager.py
@@ -11,48 +11,53 @@ class DummyProgram:
 
 
 class TestProgramTypeManager:
-    def setup_method(self):
-        self.manager = ProgramTypeManager()
+    @pytest.fixture
+    def manager(self):
+        return ProgramTypeManager()
 
-    def test_register_type(self):
-        self.manager.register_type("dummy", DummyProgram)
+    def test_register_type(self, manager: ProgramTypeManager):
+        manager.register_type("dummy", DummyProgram)
         program = DummyProgram()
 
-        result = self.manager.detect_lib(program)
+        result = manager.resolve_lib(program)
 
         assert result == "dummy"
 
-    def test_detect_lib_returns_none_for_unregistered_type(self):
+    def test_resolve_lib_returns_none_for_unregistered_type(
+        self, manager: ProgramTypeManager
+    ):
         program = DummyProgram()
 
-        result = self.manager.detect_lib(program)
+        result = manager.resolve_lib(program)
 
         assert result is None
 
-    def test_detect_lib_with_multiple_registrations(self):
+    def test_resolve_lib_with_multiple_registrations(self, manager: ProgramTypeManager):
         class AnotherDummyProgram:
             pass
 
-        self.manager.register_type("dummy1", DummyProgram)
-        self.manager.register_type("dummy2", AnotherDummyProgram)
+        manager.register_type("dummy1", DummyProgram)
+        manager.register_type("dummy2", AnotherDummyProgram)
 
         program1 = DummyProgram()
         program2 = AnotherDummyProgram()
 
-        assert self.manager.detect_lib(program1) == "dummy1"
-        assert self.manager.detect_lib(program2) == "dummy2"
+        assert manager.resolve_lib(program1) == "dummy1"
+        assert manager.resolve_lib(program2) == "dummy2"
 
-    def test_register_type_multiple_times(self):
-        self.manager.register_type("dummy", DummyProgram)
-        self.manager.register_type("another_dummy", DummyProgram)
+    def test_register_type_multiple_times(self, manager: ProgramTypeManager):
+        manager.register_type("dummy", DummyProgram)
+        manager.register_type("another_dummy", DummyProgram)
 
         program = DummyProgram()
 
         # The last registered library identifier is returned
-        assert self.manager.detect_lib(program) == "another_dummy"
+        assert manager.resolve_lib(program) == "another_dummy"
 
-    def test_register_type_raises_error_when_lib_already_registered(self):
-        self.manager.register_type("dummy", DummyProgram)
+    def test_register_type_raises_error_when_lib_already_registered(
+        self, manager: ProgramTypeManager
+    ):
+        manager.register_type("dummy", DummyProgram)
 
         class AnotherProgram:
             pass
@@ -64,4 +69,4 @@ class TestProgramTypeManager:
                 "Use allow_override=True to force registration."
             ),
         ):
-            (self.manager.register_type("dummy", AnotherProgram),)
+            manager.register_type("dummy", AnotherProgram)

--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -14,7 +14,7 @@ from tranqu.transpiler_dispatcher import (
     DeviceConversionPathNotFoundError,
     DeviceNotSpecifiedError,
     ProgramConversionPathNotFoundError,
-    ProgramLibNotFoundError,
+    ProgramLibResolutionError,
     ProgramNotSpecifiedError,
     TranspilerLibNotSpecifiedError,
 )
@@ -259,7 +259,7 @@ c[1] = measure $2;
         circuit = UnknownCircuit()
 
         with pytest.raises(
-            ProgramLibNotFoundError, match="Could not detect program library."
+            ProgramLibResolutionError, match="Could not resolve program library."
         ):
             tranqu.transpile(
                 circuit,


### PR DESCRIPTION
## ✍ Description
- Split dispatch() logic into smaller, focused helper methods
- Improve code readability and maintainability
- Make the quantum circuit conversion flow more explicit

