### PR TITLE
test: support Qiskit 2.3.0 in transpiler integration tests

### DIFF
--- a/tests/tranqu/test_tranqu.py
+++ b/tests/tranqu/test_tranqu.py
@@ -5,6 +5,8 @@ import re
 import pytest
 from pytket import Circuit  # type: ignore[attr-defined]
 from qiskit import QuantumCircuit  # type: ignore[import-untyped]
+from qiskit.qasm3 import loads
+from qiskit.quantum_info import Statevector
 from qiskit_ibm_runtime.fake_provider import FakeSantiagoV2
 
 from tranqu import Tranqu, __version__
@@ -46,6 +48,45 @@ class QiskitToEnigmaConverter(ProgramConverter):
 @pytest.fixture
 def tranqu() -> Tranqu:
     return Tranqu()
+
+
+def assert_semantically_valid_oqtopus_qiskit_qasm(transpiled_program: str) -> None:
+    assert transpiled_program.startswith(
+        'OPENQASM 3.0;\ninclude "stdgates.inc";\nbit[2] c;\n'
+    )
+
+    transpiled_circuit = loads(transpiled_program)
+
+    assert transpiled_circuit.count_ops().get("cx", 0) == 1
+    assert transpiled_circuit.count_ops().get("measure", 0) == 2
+
+    measurement_mapping = {}
+    for instruction in transpiled_circuit.data:
+        if instruction.operation.name != "measure":
+            continue
+        qubit_index = transpiled_circuit.find_bit(instruction.qubits[0]).index
+        clbit_index = transpiled_circuit.find_bit(instruction.clbits[0]).index
+        measurement_mapping[clbit_index] = qubit_index
+
+    assert set(measurement_mapping) == {0, 1}
+
+    control_qubit = measurement_mapping[0]
+    target_qubit = measurement_mapping[1]
+
+    assert control_qubit != target_qubit
+    assert {control_qubit, target_qubit}.issubset({0, 1, 2, 3})
+
+    expected_circuit = QuantumCircuit(transpiled_circuit.num_qubits)
+    expected_circuit.h(control_qubit)
+    expected_circuit.cx(control_qubit, target_qubit)
+
+    actual_without_measurements = transpiled_circuit.remove_final_measurements(
+        inplace=False
+    )
+
+    assert Statevector.from_instruction(actual_without_measurements).equiv(
+        Statevector.from_instruction(expected_circuit)
+    )
 
 
 class TestTranqu:
@@ -149,17 +190,7 @@ c[1] = measure q[1];
                 device_lib="oqtopus",
             )
 
-            expected_program = """OPENQASM 3.0;
-include "stdgates.inc";
-bit[2] c;
-rz(pi/2) $3;
-sx $3;
-rz(pi/2) $3;
-cx $3, $2;
-c[0] = measure $3;
-c[1] = measure $2;
-"""
-            assert result.transpiled_program == expected_program
+            assert_semantically_valid_oqtopus_qiskit_qasm(result.transpiled_program)
 
     def test_program_conversion_via_qiskit(self, tranqu: Tranqu):
         tranqu._program_converter_manager._converters.clear()  # noqa: SLF001


### PR DESCRIPTION
## Summary
- make the Qiskit transpiler integration test pass with `qiskit==2.3.0`
- keep the same test valid for the currently locked older Qiskit version as well
- replace brittle OpenQASM string equality with semantic validation of the transpiled circuit

## Why
Qiskit 2.3.0 can choose a different physical qubit layout during transpilation than older versions.
The generated OpenQASM is still valid, but exact string comparison fails when the mapped qubit IDs change.

This PR updates the test so that it checks circuit meaning instead of a single exact textual layout.

## Compatibility
- verified with the current lockfile environment
- verified with `qiskit==2.3.0`
- the same test now accepts layout differences across Qiskit versions without weakening the intended behavior check

## Test Details
The updated test now:
- parses the transpiled OpenQASM back into a Qiskit circuit with `qiskit.qasm3.loads()`
- checks that the expected transpilation structure is still present
  - one `cx`
  - two final measurements
- extracts the measurement-to-physical-qubit mapping
- rebuilds the expected circuit on the mapped physical qubits
- compares circuit meaning via `Statevector` equivalence instead of full-string equality

This keeps the assertion strict about behavior while avoiding failures caused only by version-specific layout choices such as `$2` vs `$1`.

## Verification
- `uv run pytest -q`
- `uv run --with qiskit==2.3.0 pytest -q`
