### PR TITLE
ci: add environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This pull request makes a small change to the release workflow configuration by specifying the deployment environment.

- Set the `environment` field to `pypi` in the `release` job of `.github/workflows/release.yaml` to ensure deployments are associated with the correct environment.