### PR TITLE
ci: change the version of codecov/codecov-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload coverage to Codecov
         # Only upload for the primary version to avoid collisions/redundancy
         if: github.actor != 'dependabot[bot]' && matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
CI workflow maintenance:

* Updated the Codecov action in `.github/workflows/ci.yaml` from `codecov-action@v6.0.1` to `codecov-action@v6` to always use the latest v6 release.