### PR TITLE
fix: count non-gate operations consistently across transpilers (#75)

### DIFF
--- a/src/tranqu/transpiler/non_gate_operation.py
+++ b/src/tranqu/transpiler/non_gate_operation.py
@@ -1,0 +1,83 @@
+"""The single definition of which operations are not counted as gates.
+
+Gate counts reported in ``TranspileResult.stats`` must mean the same thing no
+matter which transpiler produced them. Each entry of :data:`COUNTERPARTS` names
+one kind of non-gate operation together with how every supported library
+represents it, so the decision of what counts as a gate is made here and only
+here.
+
+Adding a kind of non-gate operation means adding an entry, which forces its
+counterpart in every library to be stated -- including stating that a library
+has none.
+"""
+
+from enum import Enum, auto, unique
+from typing import NamedTuple
+
+from pytket import OpType  # type: ignore[attr-defined]
+from qiskit.circuit.controlflow import (  # type: ignore[import-untyped]
+    CONTROL_FLOW_OP_NAMES,
+)
+
+
+@unique
+class NonGateOperation(Enum):
+    """A kind of operation that is not counted as a gate."""
+
+    MEASURE = auto()
+    RESET = auto()
+    BARRIER = auto()
+    DELAY = auto()
+    INITIALIZE = auto()
+    CONTROL_FLOW = auto()
+
+
+class Counterparts(NamedTuple):
+    """How one non-gate operation is represented in each supported library.
+
+    An empty collection means the library has no counterpart for it.
+    """
+
+    qiskit_names: frozenset[str]
+    tket_op_types: frozenset[OpType]
+
+
+COUNTERPARTS: dict[NonGateOperation, Counterparts] = {
+    NonGateOperation.MEASURE: Counterparts(
+        qiskit_names=frozenset({"measure"}),
+        tket_op_types=frozenset({OpType.Measure}),
+    ),
+    NonGateOperation.RESET: Counterparts(
+        qiskit_names=frozenset({"reset"}),
+        tket_op_types=frozenset({OpType.Reset}),
+    ),
+    NonGateOperation.BARRIER: Counterparts(
+        qiskit_names=frozenset({"barrier"}),
+        tket_op_types=frozenset({OpType.Barrier}),
+    ),
+    NonGateOperation.DELAY: Counterparts(
+        qiskit_names=frozenset({"delay"}),
+        # tket has no delay operation.
+        tket_op_types=frozenset(),
+    ),
+    NonGateOperation.INITIALIZE: Counterparts(
+        qiskit_names=frozenset({"initialize"}),
+        # tket has no initialize operation.
+        tket_op_types=frozenset(),
+    ),
+    NonGateOperation.CONTROL_FLOW: Counterparts(
+        # 'if_else', 'for_loop', 'while_loop', 'switch_case'
+        qiskit_names=frozenset(CONTROL_FLOW_OP_NAMES),
+        tket_op_types=frozenset({OpType.Conditional}),
+    ),
+}
+
+QISKIT_NON_GATE_OPERATION_NAMES: frozenset[str] = frozenset(
+    name for counterparts in COUNTERPARTS.values() for name in counterparts.qiskit_names
+)
+
+TKET_NON_GATE_OP_TYPES: frozenset[OpType] = frozenset(
+    op_type
+    for counterparts in COUNTERPARTS.values()
+    for op_type in counterparts.tket_op_types
+)

--- a/src/tranqu/transpiler/qiskit_stats_extractor.py
+++ b/src/tranqu/transpiler/qiskit_stats_extractor.py
@@ -1,27 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
+
+from .non_gate_operation import QISKIT_NON_GATE_OPERATION_NAMES
 
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit  # type: ignore[import-untyped]
-from qiskit.circuit.controlflow import (  # type: ignore[import-untyped]
-    CONTROL_FLOW_OP_NAMES,
-)
+
+SINGLE_QUBIT = 1
+TWO_QUBIT = 2
 
 
 class QiskitStatsExtractor:
     """Extract statistical information from Qiskit quantum circuits."""
 
-    _NON_GATE_OPERATION: ClassVar[set[str]] = {
-        "measure",
-        "reset",
-        "barrier",
-        "delay",
-        "initialize",
-        *CONTROL_FLOW_OP_NAMES,  # 'if_else','for_loop','while_loop','switch_case'
-    }
-
-    def extract_stats_from(self, program: QuantumCircuit) -> dict[str, int]:
+    @staticmethod
+    def extract_stats_from(program: QuantumCircuit) -> dict[str, int]:
         """Extract statistical information from a Qiskit quantum circuit.
 
         Args:
@@ -31,48 +25,16 @@ class QiskitStatsExtractor:
             dict[str, int]: Statistical information about the circuit.
 
         """
-        stats = {}
-        stats["n_qubits"] = program.num_qubits
-        stats["n_gates"] = self._count_gates(program)
-        stats["n_gates_1q"] = self._count_single_qubit_gates(program)
-        stats["n_gates_2q"] = self._count_two_qubit_gates(program)
-        stats["depth"] = program.depth()
-        return stats
-
-    @staticmethod
-    def _count_gates(program: QuantumCircuit) -> int:
-        # sum non_gate operation
-        return sum(
-            1
+        gates = [
+            instruction
             for instruction in program.data
-            if instruction.operation.name
-            not in QiskitStatsExtractor._NON_GATE_OPERATION
-        )
+            if instruction.operation.name not in QISKIT_NON_GATE_OPERATION_NAMES
+        ]
 
-    @staticmethod
-    def _count_single_qubit_gates(program: QuantumCircuit) -> int:
-        data = program.data
-        count = 0
-        for instruction in data:
-            # is 1 qubit?
-            if len(instruction.qubits) != 1:
-                continue
-            # is non gate opration?
-            if instruction.operation.name in QiskitStatsExtractor._NON_GATE_OPERATION:
-                continue
-            count += 1
-        return count
-
-    @staticmethod
-    def _count_two_qubit_gates(program: QuantumCircuit) -> int:
-        data = program.data
-        count = 0
-        for instruction in data:
-            # is 2 qubit?
-            if len(instruction.qubits) != 2:  # noqa: PLR2004
-                continue
-            # is non gate opration?
-            if instruction.operation.name in QiskitStatsExtractor._NON_GATE_OPERATION:
-                continue
-            count += 1
-        return count
+        return {
+            "n_qubits": program.num_qubits,
+            "n_gates": len(gates),
+            "n_gates_1q": sum(1 for gate in gates if len(gate.qubits) == SINGLE_QUBIT),
+            "n_gates_2q": sum(1 for gate in gates if len(gate.qubits) == TWO_QUBIT),
+            "depth": program.depth(),
+        }

--- a/src/tranqu/transpiler/tket_stats_extractor.py
+++ b/src/tranqu/transpiler/tket_stats_extractor.py
@@ -1,11 +1,13 @@
 from pytket import Circuit  # type: ignore[attr-defined]
 
+from .non_gate_operation import TKET_NON_GATE_OP_TYPES
+
+SINGLE_QUBIT = 1
+TWO_QUBIT = 2
+
 
 class TketStatsExtractor:
     """Extract statistical information from tket circuits."""
-
-    SINGLE_QUBIT = 1
-    TWO_QUBIT = 2
 
     @staticmethod
     def extract_stats_from(program: Circuit) -> dict[str, int]:
@@ -18,18 +20,16 @@ class TketStatsExtractor:
             dict[str, int]: Statistical information about the circuit.
 
         """
+        gates = [
+            command
+            for command in program.get_commands()
+            if command.op.type not in TKET_NON_GATE_OP_TYPES
+        ]
+
         return {
             "n_qubits": program.n_qubits,
-            "n_gates": program.n_gates,
-            "n_gates_1q": sum(
-                1
-                for cmd in program.get_commands()
-                if len(cmd.qubits) == TketStatsExtractor.SINGLE_QUBIT
-            ),
-            "n_gates_2q": sum(
-                1
-                for cmd in program.get_commands()
-                if len(cmd.qubits) == TketStatsExtractor.TWO_QUBIT
-            ),
+            "n_gates": len(gates),
+            "n_gates_1q": sum(1 for gate in gates if len(gate.qubits) == SINGLE_QUBIT),
+            "n_gates_2q": sum(1 for gate in gates if len(gate.qubits) == TWO_QUBIT),
             "depth": program.depth(),
         }

--- a/tests/tranqu/transpiler/test_non_gate_operation.py
+++ b/tests/tranqu/transpiler/test_non_gate_operation.py
@@ -1,0 +1,19 @@
+from pytket import OpType  # type: ignore[attr-defined]
+
+from tranqu.transpiler.non_gate_operation import (
+    COUNTERPARTS,
+    QISKIT_NON_GATE_OPERATION_NAMES,
+    TKET_NON_GATE_OP_TYPES,
+    NonGateOperation,
+)
+
+
+def test_every_non_gate_operation_states_its_counterparts() -> None:
+    # Adding a kind of non-gate operation must force its counterpart in every
+    # library to be stated, so that the two stats extractors cannot drift apart.
+    assert set(COUNTERPARTS) == set(NonGateOperation)
+
+
+def test_measurement_is_not_a_gate_in_either_library() -> None:
+    assert "measure" in QISKIT_NON_GATE_OPERATION_NAMES
+    assert OpType.Measure in TKET_NON_GATE_OP_TYPES

--- a/tests/tranqu/transpiler/test_stats_consistency.py
+++ b/tests/tranqu/transpiler/test_stats_consistency.py
@@ -1,0 +1,35 @@
+import pytest
+from qiskit import QuantumCircuit  # type: ignore[import-untyped]
+
+from tranqu import Tranqu
+
+
+@pytest.fixture
+def tranqu() -> Tranqu:
+    return Tranqu()
+
+
+def _circuit_with_measurements() -> QuantumCircuit:
+    circuit = QuantumCircuit(2, 2)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure(0, 0)
+    circuit.measure(1, 1)
+    return circuit
+
+
+def _stats_before(tranqu: Tranqu, transpiler_lib: str) -> dict[str, int]:
+    result = tranqu.transpile(
+        _circuit_with_measurements(),
+        program_lib="qiskit",
+        transpiler_lib=transpiler_lib,
+        transpiler_options={"optimization_level": 0},
+    )
+    return result.to_dict()["stats"]["before"]
+
+
+def test_stats_before_is_independent_of_transpiler_lib(tranqu: Tranqu) -> None:
+    # stats.before describes the circuit the caller passed in. The transpiler
+    # has not touched it, so the reported statistics must not depend on which
+    # transpiler library was selected.
+    assert _stats_before(tranqu, "qiskit") == _stats_before(tranqu, "tket")


### PR DESCRIPTION
## Ticket

#75

## Summary

`stats.before` describes the circuit the caller passed in, so its values must not depend on which transpiler was selected — but they did, because gate counting was implemented independently in the Qiskit and tket stats extractors and the two disagreed on what counts as a gate. This moves that decision into a single definition that both extractors consult.

Affected area: API. Statistics reported through the **tket** path change — non-gate operations (measurements, resets, barriers, conditionals) are no longer counted as gates, which makes them agree with the Qiskit path. Numbers reported through the Qiskit and ouqu-tp paths are unchanged. Worth a changelog note.

## Changes

- Add `non_gate_operation.py`, holding one entry per kind of non-gate operation together with its counterpart in each supported library, so the decision of what counts as a gate is made in one place.
- `TketStatsExtractor` now excludes non-gate operations, which fixes the reported inconsistency.
- `QiskitStatsExtractor` consults the shared definition instead of its own private set; its results are unchanged.
- Add a test asserting `stats.before` is identical across `transpiler_lib` for a circuit containing measurements. This test does not depend on which definition is chosen, only that the two agree.
- Add a test asserting every kind of non-gate operation states its counterpart in every library, so a new entry cannot silently apply to one library only.

### Notes for review

- The canonical definition follows the Qiskit behaviour, as proposed in #75. Reversing that choice means changing one table, not two implementations.
- `pytket`'s own `op.is_gate()` was not used as the basis, because it returns `True` for `Measure` and `Reset`.
- `DELAY` and `INITIALIZE` map to an empty set on the tket side, since pytket has no counterpart for them.
- The Qiskit path was checked against the previous implementation on circuits containing barriers, resets, delays, measurements, three-qubit gates, `if_else` blocks and `initialize`, and produces identical numbers in every case.
- No existing test needed changing, because no existing test exercised statistics on a circuit containing measurements — which is why the difference went unnoticed.
