### PR TITLE
fix: read coupling gate_duration "rzx90" and convert cx duration to seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ cython_debug/
 AGENTS.md
 codex.json
 plans/
+.pi-subagents/
+.serena/

--- a/src/tranqu/device_converter/oqtopus_to_qiskit_device_converter.py
+++ b/src/tranqu/device_converter/oqtopus_to_qiskit_device_converter.py
@@ -102,7 +102,13 @@ class OqtoqusToQiskitDeviceConverter(DeviceConverter):
         # cx instructions
         cx_props = {}
         for coupling in oqtopus_device["couplings"]:
-            duration = coupling.get("gate_duration", {}).get("cx")
+            gate_duration = coupling.get("gate_duration", {})
+            if "rzx90" in gate_duration:
+                duration = gate_duration["rzx90"] * 1e-9
+            elif "cx" in gate_duration:
+                duration = gate_duration["cx"] * 1e-9
+            else:
+                duration = None
             error = 1 - coupling["fidelity"] if "fidelity" in coupling else None
             cx_props[int(coupling["control"]), int(coupling["target"])] = (
                 InstructionProperties(duration=duration, error=error)

--- a/tests/tranqu/device_converter/test_oqtopus_to_qiskit_device_converter.py
+++ b/tests/tranqu/device_converter/test_oqtopus_to_qiskit_device_converter.py
@@ -102,3 +102,61 @@ class TestOqtoqusToQiskitDeviceConverter:
         result = self.converter.convert(oqtopus_device)
 
         assert isinstance(result, BackendV2)
+
+    def test_convert_coupling_rzx90_duration_to_seconds(self):
+        oqtopus_device = {
+            "device_id": "local_device",
+            "qubits": [
+                {
+                    "id": 0,
+                    "fidelity": 0.99,
+                    "gate_duration": {"x": 60.0, "sx": 30.0, "rz": 0},
+                },
+                {
+                    "id": 1,
+                    "fidelity": 0.99,
+                    "gate_duration": {"x": 60.0, "sx": 30.0, "rz": 0},
+                },
+            ],
+            "couplings": [
+                {
+                    "control": 0,
+                    "target": 1,
+                    "fidelity": 0.98,
+                    "gate_duration": {"rzx90": 200},
+                },
+            ],
+        }
+
+        target = self.converter.convert(oqtopus_device).target
+
+        assert target["cx"][0, 1].duration == pytest.approx(2e-7)
+
+    def test_convert_coupling_cx_duration_to_seconds(self):
+        oqtopus_device = {
+            "device_id": "local_device",
+            "qubits": [
+                {
+                    "id": 0,
+                    "fidelity": 0.99,
+                    "gate_duration": {"x": 60.0, "sx": 30.0, "rz": 0},
+                },
+                {
+                    "id": 1,
+                    "fidelity": 0.99,
+                    "gate_duration": {"x": 60.0, "sx": 30.0, "rz": 0},
+                },
+            ],
+            "couplings": [
+                {
+                    "control": 0,
+                    "target": 1,
+                    "fidelity": 0.98,
+                    "gate_duration": {"cx": 200},
+                },
+            ],
+        }
+
+        target = self.converter.convert(oqtopus_device).target
+
+        assert target["cx"][0, 1].duration == pytest.approx(2e-7)


### PR DESCRIPTION
## Ticket
Closes #78

## Summary
`OqtoqusToQiskitDeviceConverter` only read the two-qubit gate duration from `couplings[*].gate_duration["cx"]`, but the device info emitted by qdash / device-gateway stores it under `"rzx90"` (since qdash #111), so CX `InstructionProperties.duration` was always `None` on real device info. When `"cx"` was present it was also passed through in nanoseconds while single-qubit durations are converted to seconds.

## Changes
- Read `gate_duration["rzx90"]` (preferred) or `gate_duration["cx"]` (fallback) for couplings and convert both from ns to seconds, matching the single-qubit `x` / `sx` / `rz` handling.
- Add tests asserting `target["cx"][0, 1].duration == 2e-7` for `{"rzx90": 200}` and `{"cx": 200}`.

Not in scope (tracked separately in #78's "Ideally" note): validating the `"oqtopus"` device dict against a specific qdash schema version.

https://claude.ai/code/session_0165MyofFjEiWHq715PUYt2g
